### PR TITLE
Include roughsetDT class in __init__.py

### DIFF
--- a/src/roughsets_base/__init__.py
+++ b/src/roughsets_base/__init__.py
@@ -3,6 +3,7 @@
 """
 
 from roughsets_base.roughset_si import RoughSetSI
+from roughsets_base.roughset_dt import RoughSetDT
 
 
 def setup():


### PR DESCRIPTION
i was having trouble to use this class when i installed the library via pip. The issue appears to be attributed to Python's disregard of the class, which was not explicitly declared in the __init__.py file. After this change, the library now works as expected on my local machine.